### PR TITLE
Temporary fix for trailing commas in JSON LD files

### DIFF
--- a/.github/workflows/deploy-master.yml
+++ b/.github/workflows/deploy-master.yml
@@ -47,7 +47,7 @@ jobs:
         env:
           JEKYLL_ENV: production
         run: |
-          make _site
+          make all
 
 
       - name: Deploy to geolexica.org

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -47,7 +47,7 @@ jobs:
         env:
           JEKYLL_ENV: production
         run: |
-          make _site
+          make all
 
 
       - name: Deploy to geolexica.org

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,8 @@
 SHELL := /bin/bash
+JSON_PP := json_pp -json_opt pretty,relaxed,utf8
+GENERATED_JSONS := _site/api/concepts/*.json _site/api/concepts/*.jsonld
 
-all: _site
+all: _site | postprocess
 
 clean:
 	rm -rf _site
@@ -12,6 +14,13 @@ data: _data/info.yaml _data/metadata.yaml
 
 _site: data | bundle
 	bundle exec jekyll build
+
+postprocess:
+	echo "Postprocessing JSONs..."; \
+	for f in ${GENERATED_JSONS}; do \
+		mv $${f} .tmp.json; \
+		${JSON_PP} < .tmp.json > $${f} && rm .tmp.json || mv .tmp.json $${f}; \
+	done
 
 bundle:
 	bundle
@@ -31,4 +40,4 @@ update-init:
 update-modules:
 	git submodule foreach git pull origin master
 
-.PHONY: data bundle all open serve distclean clean update-init update-modules
+.PHONY: data bundle all open serve distclean clean update-init update-modules postprocess

--- a/_config.yml
+++ b/_config.yml
@@ -153,6 +153,7 @@ geolexica:
     - turtle
 
 tidy_json:
+  enabled: false
   pretty: true
 
 exclude:


### PR DESCRIPTION
Postprocessing with Perl's JSON::PP solves many syntactical issues. It is slow and reorders JSON entries, which is bad for diffing, though.

Jekyll-Tidy-JSON has no use in this case, so it is disabled.

Fixes #108, though there are more known issues with JSON-LD files.