### PR TITLE
Update Jekyll-Geolexica, and accordingly configuration

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/geolexica/geolexica-server.git
-  revision: 247801294349d1191621109261c901cbfc14d21e
+  revision: 4c6d54fc6867b0f81acc40281c59971127e95a01
   specs:
     jekyll-geolexica (0.1.0)
       jekyll (~> 3.8.5)

--- a/_config.yml
+++ b/_config.yml
@@ -127,6 +127,11 @@ defaults:
     values:
       layout: concept.ttl
       permalink: /api/concepts/:name.ttl
+  - scope:
+      path: ""
+      type: "posts"
+    values:
+      show_header_meta: true
 
 geolexica:
   concepts_glob: "./isotc211-glossary/concepts/*.yaml"


### PR DESCRIPTION
A new version of Jekyll-Geolexica brings changes on how date/version meta information is rendered. Now it must be explicitly enabled, here it's done via configuration.