### PR TITLE
Update Geolexica-Site to 1.2 and reconfigure deploys

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -44,8 +44,6 @@ jobs:
         run: |
           npm install
       - name: Build site
-        env:
-          JEKYLL_ENV: production
         run: |
           make all
 

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,3 @@
 source "https://rubygems.org"
 
-gem "geolexica-site", "1.0.0"
+gem "geolexica-site", "1.2.0"


### PR DESCRIPTION
Build staging site without `JEKYLL_ENV=production`. It makes sense in Geolexica-Site 1.2 as since this version crawlers are disallowed for non-production sites via robots.txt.