### PR TITLE
Update language data

### DIFF
--- a/_source/_data/lang.yaml
+++ b/_source/_data/lang.yaml
@@ -64,6 +64,12 @@ pol:
   iso-639-1: pl
   example: PRZYKŁAD
   note_to_entry: "UWAGA DD:"
+por:
+  lang_native: português
+  lang_en: Portuguese
+  iso-639-1: pt
+  exemplo: EXEMPLO
+  note_to_entry: "Anote o DD na entrada:"
 rus:
   lang_native: Русский язык
   lang_en: Russian

--- a/_source/_data/lang.yaml
+++ b/_source/_data/lang.yaml
@@ -37,13 +37,13 @@ fra:
 jpn:
   lang_native: 日本語
   lang_en: Japanese
-  iso-639-1: jp
+  iso-639-1: ja
   example: 例
   note_to_entry: "備考 DD："
 kor:
   lang_native: 한국어
   lang_en: Korean
-  iso-639-1: kr
+  iso-639-1: ko
   example: 보기
   note_to_entry: "비고 DD:"
 msa:

--- a/_source/_data/lang.yaml
+++ b/_source/_data/lang.yaml
@@ -1,33 +1,27 @@
-eng:
-  lang_native: English
-  lang_en: English
-  iso-639-1: en
-  example: EXAMPLE
-  note_to_entry: "Note DD to entry:"
 ara:
   lang_native: العربية
   lang_en: Arabic
   iso-639-1: ar
   example: "مثال"
   note_to_entry: "ملاحظة DD:"
-chn:
-  lang_native: 中文
-  lang_en: Chinese
-  iso-639-1: zh
-  example: 示例
-  note_to_entry: "注 DD："
 dan:
   lang_native: dansk
   lang_en: Danish
   iso-639-1: da
   example: EKSEMPEL
   note_to_entry: "NOTE DD to entry:"
-dut:
-  lang_native: Nederlands
-  lang_en: Dutch
-  iso-639-1: nl
-  example: VOORBEELD
-  note_to_entry: "OPMERKING DD:"
+ger: # TODO deu
+  lang_native: Deutsch
+  lang_en: German
+  iso-639-1: de
+  example: BEISPIEL
+  note_to_entry: "NOTE DD:"
+eng:
+  lang_native: English
+  lang_en: English
+  iso-639-1: en
+  example: EXAMPLE
+  note_to_entry: "Note DD to entry:"
 fin:
   lang_native: suomi
   lang_en: Finnish
@@ -40,12 +34,6 @@ fra:
   iso-639-1: fr
   example: EXEMPLE
   note_to_entry: "A noter DD:"
-ger:
-  lang_native: Deutsch
-  lang_en: German
-  iso-639-1: de
-  example: BEISPIEL
-  note_to_entry: "NOTE DD:"
 jpn:
   lang_native: 日本語
   lang_en: Japanese
@@ -64,6 +52,12 @@ msa:
   iso-639-1: ms
   example: Contoh
   note_to_entry: "catatan DD:"
+dut: # TODO nld
+  lang_native: Nederlands
+  lang_en: Dutch
+  iso-639-1: nl
+  example: VOORBEELD
+  note_to_entry: "OPMERKING DD:"
 pol:
   lang_native: polski
   lang_en: Polish
@@ -88,3 +82,9 @@ swe:
   iso-639-1: sv
   example: EXEMPEL
   note_to_entry: "Anm. DD till termpost:"
+chn: # TODO zho
+  lang_native: 中文
+  lang_en: Chinese
+  iso-639-1: zh
+  example: 示例
+  note_to_entry: "注 DD："

--- a/_source/_data/lang.yaml
+++ b/_source/_data/lang.yaml
@@ -9,7 +9,7 @@ dan:
   lang_en: Danish
   iso-639-1: da
   example: EKSEMPEL
-  note_to_entry: "NOTE DD to entry:"
+  note_to_entry: "Bemærk DD til posten:"
 ger: # TODO deu
   lang_native: Deutsch
   lang_en: German
@@ -33,7 +33,7 @@ fra:
   lang_en: French
   iso-639-1: fr
   example: EXEMPLE
-  note_to_entry: "A noter DD:"
+  note_to_entry: "Note DD à l'article:"
 jpn:
   lang_native: 日本語
   lang_en: Japanese


### PR DESCRIPTION
Update language data contained in `_data/lang.yml` to reflect recent fixes made to that file in Jekyll-Geolexica gem. Three letter codes must remain different, as the termbase does not follow proper ISO standards yet. These three letter codes are the only reason why this file is overridden for TC211 site.