### PR TITLE
Fix language codes in search

### DIFF
--- a/_source/assets/js/concept-search-worker.js
+++ b/_source/assets/js/concept-search-worker.js
@@ -5,16 +5,19 @@ const CONCEPTS_URL = '/api/concepts-index-list.json';
 const LANGUAGES = [
   'eng',
   'ara',
+  'dan',
+  'deu',
+  'fin',
+  'fra',
+  'jpn',
+  'kor',
+  'msa',
+  'nld',
+  'pol',
+  'rus',
   'spa',
   'swe',
-  'kor',
-  'rus',
-  'ger',
-  'fre',
-  'fin',
-  'jpn',
-  'dan',
-  'chi',
+  'zho',
 ];
 
 var concepts = null;

--- a/_source/assets/js/concept-search.js
+++ b/_source/assets/js/concept-search.js
@@ -6,16 +6,19 @@
   const LANGUAGES = [
     'eng',
     'ara',
+    'dan',
+    'deu',
+    'fin',
+    'fra',
+    'jpn',
+    'kor',
+    'msa',
+    'nld',
+    'pol',
+    'rus',
     'spa',
     'swe',
-    'kor',
-    'rus',
-    'ger',
-    'fre',
-    'fin',
-    'jpn',
-    'dan',
-    'chi',
+    'zho',
   ];
 
 


### PR DESCRIPTION
Language codes in search are hardcoded (see https://github.com/geolexica/geolexica-server/issues/123). Unfortunately, they were also outdated, causing most of the problem reported in #147.

This pull request fixes search feature for Chinese, Dutch, French, German, Malay, and Polish. Fixes #147.