### PR TITLE
Fix configured site url

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -33,7 +33,7 @@ description: >-
   The authoritative glossary for geographic information technology from ISO/TC 211.
 
 baseurl: ""
-url: "https://isotc211.geolexica.org/"
+url: "https://isotc211.geolexica.org"
 
 social:
   links:


### PR DESCRIPTION
Remove trailing slash from `url` field in `_config.yml`.  It was a cause of excessive slashes in absolute URLs, e.g. in `sitemap.xml`.

Fixes #152.