### PR TITLE
added semantic searching beta in isotc211

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   build-deploy:
-    uses: geolexica/ci/.github/workflows/site-deploy-breviter.yml@main
+    uses: geolexica/ci/.github/workflows/site-deploy-breviter.yml@breviter_ci_beta
     with:
       repository: geolexica/isotc211-glossary
       concepts-path: isotc211-glossary

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,10 +12,12 @@ on:
 
 jobs:
   build-deploy:
-    uses: geolexica/ci/.github/workflows/site-deploy.yml@main
+    uses: geolexica/ci/.github/workflows/site-deploy-breviter.yml@main
     with:
       repository: geolexica/isotc211-glossary
       concepts-path: isotc211-glossary
+      breviter-repository: geolexica/breviter
+      breviter-path: breviter
       environment-name: ${{ github.ref == 'refs/heads/main' && 'production' || 'staging' }}
       environment-url: ${{ github.ref == 'refs/heads/main' && 'https://isotc211.geolexica.org' || 'https://isotc211-staging.geolexica.org' }}
       production-branch: refs/heads/main

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   build-deploy:
-    uses: geolexica/ci/.github/workflows/site-deploy-breviter.yml@breviter_ci_beta
+    uses: geolexica/ci/.github/workflows/site-deploy-breviter.yml@main
     with:
       repository: geolexica/isotc211-glossary
       concepts-path: isotc211-glossary

--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ tc211-termbase.xlsx
 # These are generated from the Makefile
 _source/_data/info.yaml
 _source/_data/metadata.yaml
+_source/_next

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "isotc211-glossary"]
 	path = isotc211-glossary
 	url = git@github.com:geolexica/isotc211-glossary.git
+[submodule "breviter"]
+	path = breviter
+	url = git@github.com:geolexica/breviter.git

--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,5 @@
 source "https://rubygems.org"
 
 gem "geolexica-site", "1.7.0"
-gem "jekyll-geolexica", git: "https://github.com/geolexica/geolexica-server"
+gem "jekyll-geolexica", git: "https://github.com/geolexica/jekyll-geolexica"
 

--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,5 @@
 source "https://rubygems.org"
 
-gem "geolexica-site", "1.7.0"
+gem "geolexica-site", git: "https://github.com/HassanAkbar/geolexica-site"
 gem "jekyll-geolexica", git: "https://github.com/geolexica/jekyll-geolexica"
 

--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,3 @@
 source "https://rubygems.org"
 
-gem "geolexica-site", git: "https://github.com/HassanAkbar/geolexica-site"
-gem "jekyll-geolexica", git: "https://github.com/geolexica/jekyll-geolexica"
-
+gem "geolexica-site", git: "https://github.com/geolexica/geolexica-site"

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ all: _site
 clean:
 	rm -rf _site _source/_data/info.yaml _source/_data/metadata.yaml
 
-data: _source/_data/info.yaml _source/_data/metadata.yaml
+data: _source/_data/info.yaml _source/_data/metadata.yaml | _source/_next
 
 _site: data | bundle
 	bundle exec jekyll build
@@ -22,6 +22,13 @@ postprocess:
 
 bundle:
 	bundle
+
+_source/_next: breviter/.next
+	mkdir $@
+	cp -rf $</. $@/
+
+breviter/.next:
+	cd breviter && yarn install && yarn build
 
 _source/_data/info.yaml: isotc211-glossary/tc211-termbase.meta.yaml
 	cp -f $< $@

--- a/_config.yml
+++ b/_config.yml
@@ -69,6 +69,9 @@ nav:
   - id: feedback
     url: /feedback
     title: Feedback
+  - id: semantic-search
+    url: /_next/server/pages/reverse
+    title: Semantic Search
 
 footer_nav:
   - url: https://committee.iso.org/home/tc211
@@ -135,3 +138,11 @@ plugins:
   - jekyll-sitemap
   - jekyll-tidy-json
   - jekyll-plugin-frontend-build
+
+include:
+  # Next.js build files
+  - _next
+  - _app
+  - _error
+  - _buildManifest
+  - _ssgManifest

--- a/_source/_pages/about.adoc
+++ b/_source/_pages/about.adoc
@@ -3,7 +3,7 @@ layout: base-page
 title: About
 permalink: /about/
 bodyClass: page
-nav_items: [concepts, posts, stats, feedback, registers]
+nav_items: [concepts, posts, stats, feedback, registers, semantic-search]
 ---
 :page-liquid:
 

--- a/_source/_pages/feedback.adoc
+++ b/_source/_pages/feedback.adoc
@@ -3,7 +3,7 @@ layout: base-page
 title: Feedback
 permalink: /feedback/
 bodyClass: page
-nav_items: [concepts, posts, stats, registers, about]
+nav_items: [concepts, posts, stats, registers, about, semantic-search]
 ---
 Please feel free to send your thoughts about ISO/TC 211 MLGT,
 bug reports, or just kudos, through the form below. Thanks!

--- a/_source/_pages/registers.adoc
+++ b/_source/_pages/registers.adoc
@@ -3,7 +3,7 @@ layout: base-page
 title: Registers
 permalink: "/registers/index.html"
 bodyClass: page
-nav_items: [concepts, posts, stats, feedback, about]
+nav_items: [concepts, posts, stats, feedback, about, semantic-search]
 ---
 :page-liquid:
 

--- a/_source/_pages/semantic-search.adoc
+++ b/_source/_pages/semantic-search.adoc
@@ -1,0 +1,1 @@
+This is for semantic searcing


### PR DESCRIPTION
1. Add Breviter as a submodule into the `isotc211.geolexica.org` repo
2. Add steps in the Makefile to go into `breviter` directory and do a `yarn build` and copy output to the `isotc211.geolexica.org` repo.
3. Convert the name of the returned items from Breviter into links to the `isotc211.geolexica.org` concept. (Done in this PR -> https://github.com/geolexica/breviter/pull/25).

resolves #174 