### PR TITLE
using paneron structure for site generation

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -100,7 +100,9 @@ defaults:
       show_header_meta: true
 
 geolexica:
-  concepts_glob: "../isotc211-glossary/concepts/*.yaml"
+  concepts_glob: "../isotc211-glossary/geolexica/concept/*.yaml"
+  localized_concepts_path: "../isotc211-glossary/geolexica/localized-concept"
+  format: "paneron"
   math: true
   term_languages:
     - eng

--- a/scripts/generate_metadata.rb
+++ b/scripts/generate_metadata.rb
@@ -16,7 +16,7 @@ end.sum
 meta = {
   "concept_count" => terms.length,
   "term_count" => term_count,
-  "version" => "20230420"
+  "version" => "20230420",
 }
 
 File.open("metadata.yaml", "w") do |file|

--- a/scripts/generate_metadata.rb
+++ b/scripts/generate_metadata.rb
@@ -1,10 +1,10 @@
 #!/usr/bin/env ruby
 
-require 'yaml'
-require 'date'
+require "yaml"
+require "date"
 
 terms = []
-Dir['isotc211-glossary/geolexica/concept/*.yaml'].map do |yaml_file|
+Dir["isotc211-glossary/geolexica/concept/*.yaml"].map do |yaml_file|
   terms << YAML.safe_load(IO.read(yaml_file), permitted_classes: [Date, Time])
   puts "Processing #{yaml_file}"
 end
@@ -14,12 +14,12 @@ term_count = terms.map do |t|
 end.sum
 
 meta = {
-  'concept_count' => terms.length,
-  'term_count' => term_count,
-  'version' => '20230420'
+  "concept_count" => terms.length,
+  "term_count" => term_count,
+  "version" => "20230420"
 }
 
-File.open('metadata.yaml', 'w') do |file|
+File.open("metadata.yaml", "w") do |file|
   file.write(meta.to_yaml)
 end
 

--- a/scripts/generate_metadata.rb
+++ b/scripts/generate_metadata.rb
@@ -1,21 +1,22 @@
 #!/usr/bin/env ruby
 
 require 'yaml'
+require 'date'
 
 terms = []
-Dir['isotc211-glossary/concepts/*.yaml'].map do |yaml_file|
-  terms << YAML.safe_load(IO.read(yaml_file), permitted_classes: [Time])
+Dir['isotc211-glossary/geolexica/concept/*.yaml'].map do |yaml_file|
+  terms << YAML.safe_load(IO.read(yaml_file), permitted_classes: [Date, Time])
   puts "Processing #{yaml_file}"
 end
 
 term_count = terms.map do |t|
-  t.keys.length - 2
+  t["data"]["localizedConcepts"].count
 end.sum
 
 meta = {
   'concept_count' => terms.length,
   'term_count' => term_count,
-  'version' => '20200602'
+  'version' => '20230420'
 }
 
 File.open('metadata.yaml', 'w') do |file|


### PR DESCRIPTION
Will need to merge this after merging `jekyll-geolexica` updates to use the new `paneron` structure for site generation

jekyll-geolexica PR -> https://github.com/geolexica/jekyll-geolexica/pull/10

Note: Need to release `jekyll-geolexica` version for the test cases to pass.