### PR TITLE
Use full GCR package for compiled format support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,62 +1,56 @@
-name: deploy
+name: build_deploy
 
 on:
   push:
-    branches:
-      - main
-      - staging
+    branches: [main]
   pull_request:
   repository_dispatch:
-    types:
-    - deploy
+    types: [deploy]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
 
 jobs:
-  prepare:
+  build:
     runs-on: ubuntu-latest
-    outputs:
-      environment-name: ${{ steps.prepare.outputs.environment-name }}
-      environment-url: ${{ steps.prepare.outputs.environment-url }}
+    environment:
+      name: production
+      url: https://isotc211.geolexica.org
     steps:
-    - id: prepare
-      run: |
-        if [ "${{ github.event_name }}" = "repository_dispatch" ]; then
-          ref="${{ github.event.client_payload.ref }}"
-          >&2 echo ref="${{ github.event.client_payload.ref }}"
-        else
-          ref="${{ github.ref }}"
-          >&2 echo ref="${{ github.ref }}"
-        fi
+      - uses: actions/checkout@v4
 
-        if [ "$ref" = "refs/heads/main" ]; then
-          echo "environment-name=production" >> $GITHUB_OUTPUT
-          echo "environment-url=https://isotc211-staging.geolexica.org" >> $GITHUB_OUTPUT
-          >&2 echo '"environment-name=production" >> $GITHUB_OUTPUT'
-          >&2 echo '"environment-url=https://isotc211-staging.geolexica.org" >> $GITHUB_OUTPUT'
-        elif [ "$ref" = "refs/heads/staging" ]; then
-          echo "environment-name=staging" >> $GITHUB_OUTPUT
-          echo "environment-url=https://isotc211.geolexica.org" >> $GITHUB_OUTPUT
-          >&2 echo '"environment-name=staging" >> $GITHUB_OUTPUT'
-          >&2 echo '"environment-url=https://isotc211.geolexica.org" >> $GITHUB_OUTPUT'
-        else
-          echo "environment-name=skip" >> $GITHUB_OUTPUT
-          >&2 echo '"environment-name=skip" >> $GITHUB_OUTPUT'
-        fi
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
 
-  build-deploy:
-    needs: prepare
-    uses: geolexica/ci/.github/workflows/site-deploy-breviter.yml@main
-    with:
-      repository: geolexica/isotc211-glossary
-      concepts-path: isotc211-glossary
-      breviter-repository: geolexica/breviter
-      breviter-path: breviter
-      environment-name: ${{ needs.prepare.outputs.environment-name }}
-      environment-url: ${{ needs.prepare.outputs.environment-url }}
-      production-branch: refs/heads/main
-      staging-branch: refs/heads/staging
-    secrets:
-      aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-      aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-      aws-region: ${{ secrets.AWS_REGION }}
-      aws-cf-distribution-id: ${{ secrets.CLOUDFRONT_DISTRIBUTION_ID }}
-      aws-s3-bucket-name: ${{ secrets.S3_BUCKET_NAME }}
+      - name: Install concept-browser
+        run: npm install @glossarist/concept-browser
+
+      - name: Build site
+        run: npx concept-browser build
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: dist
+
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    if: ${{ github.ref == 'refs/heads/main' }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/site-config.yml
+++ b/site-config.yml
@@ -1,0 +1,68 @@
+id: isotc211
+domain: isotc211.geolexica.org
+title: ISO/TC 211 Multi-Lingual Glossary
+description: Geographic information terminology from ISO/TC 211.
+
+datasets:
+  - id: isotc211
+    uri: "https://glossarist.org/isotc211/*"
+    gcrPackage: https://github.com/geolexica/isotc211-glossary/releases/latest/download/isotc211.gcr
+    sourceRepo: https://github.com/geolexica/isotc211-glossary
+    title: "ISO/TC 211 Multi-Lingual Glossary"
+    description: "Geographic information terminology"
+    owner: ISO/TC 211
+    color: "#0d9488"
+
+routing:
+  - uri: "urn:iec:std:iec:60050:*"
+    type: url
+    url: "https://electropedia.org/iev/iev.nsf/display?openform&ievref={conceptId}"
+    label: "IEC Electropedia"
+
+  - uri: "https://glossarist.org/iev/*"
+    type: url
+    url: "https://electropedia.org/iev/iev.nsf/display?openform&ievref={conceptId}"
+    label: "IEC Electropedia"
+
+  - uri: "urn:iso:std:iso:14812:*"
+    type: site
+    baseUrl: "https://isotc204.geolexica.org"
+    label: "ISO/TC 204 ITS Vocabulary"
+
+  - uri: "https://glossarist.org/isotc204/*"
+    type: site
+    baseUrl: "https://isotc204.geolexica.org"
+    label: "ISO/TC 204 ITS Vocabulary"
+
+  - uri: "https://glossarist.org/osgeo/*"
+    type: site
+    baseUrl: "https://osgeo.geolexica.org"
+    label: "OSGeo Lexicon"
+
+branding:
+  primaryColor: "#e3000f"
+  darkColor: "#333333"
+  fonts:
+    header:
+      family: "Roboto Condensed"
+      source: google
+      weights: [700]
+    body:
+      family: "Roboto"
+      source: google
+      weights: [400, 500, 700]
+  logo:
+    path: /logos/isotc211-logo.svg
+    alt: "ISO"
+  ownerName: "ISO/TC 211"
+  ownerUrl: https://isotc211.geolexica.org
+
+features:
+  news: false
+  stats: true
+  graph: true
+  about: true
+  search: true
+
+defaults:
+  language: eng

--- a/site-config.yml
+++ b/site-config.yml
@@ -6,7 +6,7 @@ description: Geographic information terminology from ISO/TC 211.
 datasets:
   - id: isotc211
     uri: "https://glossarist.org/isotc211/*"
-    gcrPackage: https://github.com/geolexica/isotc211-glossary/releases/latest/download/isotc211.gcr
+    gcrPackage: https://github.com/geolexica/isotc211-glossary/releases/latest/download/isotc211-full.gcr
     sourceRepo: https://github.com/geolexica/isotc211-glossary
     title: "ISO/TC 211 Multi-Lingual Glossary"
     description: "Geographic information terminology"
@@ -54,15 +54,29 @@ branding:
   logo:
     path: /logos/isotc211-logo.svg
     alt: "ISO"
+    localPath: logos/isotc211-logo.svg
   ownerName: "ISO/TC 211"
   ownerUrl: https://isotc211.geolexica.org
 
 features:
-  news: false
+  news: true
   stats: true
   graph: true
   about: true
   search: true
+
+pages:
+  - type: news
+    route: news
+    title: News
+    icon: newspaper
+    source: _source/_posts
+  - type: contributors
+    route: contributors
+    title: Contributors
+    icon: users
+
+newsDir: _source/_posts
 
 defaults:
   language: eng


### PR DESCRIPTION
## Changes
- Reference isotc211-full.gcr from GitHub Releases
- Enables per-concept format downloads (Turtle, YAML) in the concept browser

Depends on geolexica/isotc211-glossary#64 (dual GCR publishing).