### PR TITLE
Add about content page

### DIFF
--- a/about.md
+++ b/about.md
@@ -1,0 +1,58 @@
+---
+title: About
+---
+
+# About the ISO/TC 211 Multi-Lingual Glossary
+
+## ISO/TC 211 — Geographic Information/Geomatics
+
+ISO/TC 211 is a technical committee of the International Organization for Standardization (ISO) responsible for developing standards in the field of geographic information and geomatics. Established in 1994, the committee creates international standards that facilitate the discovery, access, integration, and use of geographic information.
+
+The committee's standards cover a wide range of topics including spatial referencing, data quality, metadata, feature cataloguing, portrayal, services, and encoding of geographic information. These standards form the foundation of spatial data infrastructures worldwide and are used by national mapping agencies, geographic information system (GIS) vendors, and organizations that produce or consume geospatial data.
+
+## The Multi-Lingual Glossary
+
+The ISO/TC 211 Multi-Lingual Glossary (MLG) is a comprehensive, multilingual terminology resource that defines and manages the technical vocabulary used across ISO/TC 211 standards. The glossary serves as an authoritative register of geographic information terms, providing consistent definitions in multiple languages.
+
+### Scope and Coverage
+
+The glossary contains over 1,500 concepts spanning the full breadth of geographic information standardization, including:
+
+- **Geometric and topological concepts** — primitives, complexes, and aggregates used to represent spatial features
+- **Data quality and metadata** — terms for describing the quality, lineage, and characteristics of geographic datasets
+- **Coordinate reference systems** — spatial referencing by coordinates and geographic identifiers
+- **Feature cataloguing and application schemas** — rules for defining feature types and their attributes
+- **Geospatial services** — terminology for cataloguing, processing, and portrayal services
+- **Encoding and transfer** — formats and structures for encoding geographic information
+
+### Multilingualism
+
+One of the distinguishing features of the MLG is its multilingual coverage. Terms and definitions are maintained in multiple languages, reflecting the international scope of ISO/TC 211's standardization work. Languages currently represented include Arabic, Chinese, Danish, Dutch, Finnish, French, German, Japanese, Korean, Malay, Polish, Russian, Spanish, Swedish, and English.
+
+This multilingual approach ensures that ISO geographic information standards are accessible and implementable across diverse linguistic and cultural contexts.
+
+## Terminology Register
+
+The glossary operates as a formal terminology register, with clearly defined roles for its management and maintenance:
+
+- **Register Owner** — ISO/TC 211, responsible for the overall governance of the register
+- **Register Manager** — The ISO/TC 211 Terminology Maintenance Group (TMG), responsible for day-to-day management
+- **Submitting Organizations** — National standards bodies and expert groups that contribute terminology in their respective languages
+
+This structured governance ensures the quality, consistency, and authority of the terminology maintained in the register.
+
+## Source and Collaboration
+
+The source terminology data is maintained in the [ISO/TC 211 Glossary repository](https://github.com/geolexica/isotc211-glossary) on GitHub, where it undergoes continuous improvement through community contribution and expert review.
+
+## Technical Platform
+
+This site is built with the [Glossarist Concept Browser](https://github.com/geolexista/glossarist-vocabulary-browser), an open-source tool for browsing, searching, and exploring structured terminology datasets. The Glossarist ecosystem provides tools for managing, packaging, and publishing terminology data in standardized formats.
+
+## Contact
+
+For questions about ISO/TC 211 terminology or to contribute to the glossary:
+
+- **ISO/TC 211 Secretariat**: SIS (Swedish Standards Institute)
+- **TMG Convener**: Reese Plews (rplews@tc211tmg.org)
+- **GitHub**: [github.com/geolexica/isotc211-glossary](https://github.com/geolexica/isotc211-glossary)

--- a/site-config.yml
+++ b/site-config.yml
@@ -80,6 +80,7 @@ pages:
     title: About
     icon: info
     datasetScoped: true
+    source: about.md
 
 newsDir: news
 


### PR DESCRIPTION
Real about page with ISO/TC 211 MLG information in markdown. Requires concept-browser v0.2.6+ for content page rendering.