### PR TITLE
Add uriBase to site config

### DIFF
--- a/site-config.yml
+++ b/site-config.yml
@@ -1,5 +1,6 @@
 id: isotc211
 domain: isotc211.geolexica.org
+uriBase: https://isotc211.geolexica.org
 title: ISO/TC 211 Multi-Lingual Glossary
 description: Geographic information terminology from ISO/TC 211.
 


### PR DESCRIPTION
Sets uriBase: https://isotc211.geolexica.org for concept URI generation. Required by concept-browser v0.2.7+.