### PR TITLE
Fix about page: show at /about globally, not only dataset-scoped

### DIFF
--- a/site-config.yml
+++ b/site-config.yml
@@ -80,7 +80,6 @@ pages:
     route: about
     title: About
     icon: info
-    datasetScoped: true
     source: about.md
 
 newsDir: news


### PR DESCRIPTION
The about page was marked `datasetScoped: true`, making it only accessible under `/dataset/isotc211/about` with no nav link at the global level. This removes `datasetScoped` so it appears at `/about` in the global nav, consistent with isotc204 and osgeo.